### PR TITLE
UI Components for editing a template

### DIFF
--- a/app/src/main/java/io/joelt/texttemplate/models/Template.kt
+++ b/app/src/main/java/io/joelt/texttemplate/models/Template.kt
@@ -1,3 +1,12 @@
 package io.joelt.texttemplate.models
 
-data class Template(val name: String, val templateText: String)
+import io.joelt.texttemplate.models.slots.Slot
+
+data class Template(val name: String, val slots: List<Either<String, Slot>>) {
+    constructor(name: String, text: String): this(name, text.toTemplateSlot())
+
+    val text: String
+        get() {
+            return serializeTemplate(slots)
+        }
+}

--- a/app/src/main/java/io/joelt/texttemplate/models/Template.kt
+++ b/app/src/main/java/io/joelt/texttemplate/models/Template.kt
@@ -10,3 +10,29 @@ data class Template(val name: String, val slots: List<Either<String, Slot>>) {
             return serializeTemplate(slots)
         }
 }
+
+fun List<Either<String, Slot>>.nextSlot(from: Int): Int {
+    if (from >= this.lastIndex) {
+        return -1
+    }
+
+    this.subList(from + 1, this.size).forEachIndexed { index, either ->
+        if (either is Either.Right) {
+            return from + 1 + index
+        }
+    }
+    return -1
+}
+
+fun List<Either<String, Slot>>.prevSlot(from: Int): Int {
+    if (from <= 0) {
+        return -1
+    }
+
+    this.subList(0, from).asReversed().forEachIndexed { index, either ->
+        if (either is Either.Right) {
+            return from - index - 1
+        }
+    }
+    return -1
+}

--- a/app/src/main/java/io/joelt/texttemplate/models/slots/PlainTextSlot.kt
+++ b/app/src/main/java/io/joelt/texttemplate/models/slots/PlainTextSlot.kt
@@ -1,6 +1,6 @@
 package io.joelt.texttemplate.models.slots
 
-class PlainTextSlot(var value: String) : Slot() {
+data class PlainTextSlot(var value: String) : Slot() {
     override val placeholderStr = "Text"
     override fun valueToDisplayString(): String = value
     override fun serializeValue() = value

--- a/app/src/main/java/io/joelt/texttemplate/models/slots/findSlotTag.kt
+++ b/app/src/main/java/io/joelt/texttemplate/models/slots/findSlotTag.kt
@@ -1,6 +1,6 @@
 package io.joelt.texttemplate.models.slots
 
-private val regex = Regex("\\{%\\s*(\\S*)\\s*%}")
+private val regex = Regex("\\{%\\s*(\\S*)\\s*%\\}")
 
 fun findSlotTag(text: String): Triple<String, String?, String> {
     val match = regex.find(text) ?: return Triple(text, null, "")

--- a/app/src/main/java/io/joelt/texttemplate/ui/components/SlotEditField.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/components/SlotEditField.kt
@@ -1,8 +1,11 @@
 package io.joelt.texttemplate.ui.components
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Text
-import androidx.compose.material.TextField
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
@@ -30,13 +33,41 @@ fun createSlotText(slot: Slot, selected: Boolean = false): AnnotatedString {
 }
 
 @Composable
-fun SlotEditField(slot: Slot, onChange: (newSlot: Slot) -> Unit) {
-    when (slot) {
-        is PlainTextSlot -> {
-            TextField(value = slot.value, onValueChange = {
-                onChange(slot.copy(value = it))
-            })
+fun SwitchSlotButton(isLeft: Boolean, onClick: (() -> Unit)?) {
+    var icon = Icons.Filled.KeyboardArrowLeft
+    var description = "previous slot"
+    if (!isLeft) {
+        icon = Icons.Filled.KeyboardArrowRight
+        description = "next slot"
+    }
+
+    var tint = Color.Black
+    if (onClick == null) {
+        tint = Color.Gray
+    }
+
+    IconButton(onClick = onClick ?: {}, ) {
+        Icon(icon, description, tint = tint)
+    }
+}
+
+@Composable
+fun SlotEditField(
+    slot: Slot,
+    onLeft: (() -> Unit)? = null,
+    onRight: (() -> Unit)? = null,
+    onChange: (newSlot: Slot) -> Unit
+) {
+    Row {
+        SwitchSlotButton(isLeft = true, onLeft)
+        when (slot) {
+            is PlainTextSlot -> {
+                TextField(value = slot.value, onValueChange = {
+                    onChange(slot.copy(value = it))
+                })
+            }
         }
+        SwitchSlotButton(isLeft = false, onRight)
     }
 }
 

--- a/app/src/main/java/io/joelt/texttemplate/ui/components/SlotEditField.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/components/SlotEditField.kt
@@ -1,0 +1,65 @@
+package io.joelt.texttemplate.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import io.joelt.texttemplate.models.slots.PlainTextSlot
+import io.joelt.texttemplate.models.slots.Slot
+
+fun createSlotText(slot: Slot, selected: Boolean = false): AnnotatedString {
+    when (slot) {
+        is PlainTextSlot -> {
+            return buildAnnotatedString {
+                val bgColor = if (selected) { Color.Yellow } else { Color.Gray }
+                withStyle(SpanStyle(background = bgColor)) {
+                    val str = slot.toDisplayString()
+                    append(str)
+                }
+            }
+        }
+    }
+
+    throw Exception("slot type not recognised")
+}
+
+@Composable
+fun SlotEditField(slot: Slot, onChange: (newSlot: Slot) -> Unit) {
+    when (slot) {
+        is PlainTextSlot -> {
+            TextField(value = slot.value, onValueChange = {
+                onChange(slot.copy(value = it))
+            })
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SlotEditorPreview() {
+    val mySlot = PlainTextSlot("")
+    var slot by remember { mutableStateOf<Slot>(mySlot) }
+    Column {
+        SlotEditField(slot = slot) {
+            slot = it
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SlotTextSelected() {
+    Text(text = createSlotText(PlainTextSlot("hello world"), true))
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SlotTextNotSelected() {
+    Text(text = createSlotText(PlainTextSlot("hello world"), false))
+}

--- a/app/src/main/java/io/joelt/texttemplate/ui/components/SlotsPreview.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/components/SlotsPreview.kt
@@ -1,0 +1,96 @@
+package io.joelt.texttemplate.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
+import io.joelt.texttemplate.models.Either
+import io.joelt.texttemplate.models.Template
+import io.joelt.texttemplate.models.slots.Slot
+import io.joelt.texttemplate.ui.theme.TextTemplateTheme
+
+@Composable
+fun SlotsPreview(
+    slots: List<Either<String, Slot>>,
+    selectedSlotIndex: Int? = null,
+    style: TextStyle = TextStyle.Default,
+    onSlotClick: (slotIndex: Int) -> Unit
+) {
+    val annotatedString = buildAnnotatedString {
+        slots.forEachIndexed { slotIndex, it ->
+            when (it) {
+                is Either.Left -> {
+                    append(it.value)
+                }
+                is Either.Right -> {
+                    // Annotate the string with the slot so that it can be
+                    // retrieved later
+                    pushStringAnnotation("Slot", slotIndex.toString())
+                    append(createSlotText(
+                        it.value,
+                        selectedSlotIndex == slotIndex
+                    ))
+                    pop()
+                }
+            }
+        }
+    }
+
+    Column {
+        ClickableText(
+            text = annotatedString,
+            style = style,
+            onClick = { offset ->
+                annotatedString.getStringAnnotations(
+                    tag = "Slot", offset, offset
+                ).firstOrNull()?.let { annotation ->
+                    onSlotClick(annotation.item.toInt())
+                }
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SlotsPreviewExample() {
+    val template = Template(
+        "My Sample Template",
+        """
+            Be kind to your {% text %}{% end %}-footed {% text %}{% end %}
+            For a duck may be somebody's {% text %}{% end %},
+            Be kind to your {% text %}{% end %} in {% text %}{% end %}
+            Where the weather is always {% text %}{% end %}.
+
+            You may think that this is the {% text %}{% end %},
+            Well it is.
+        """.trimIndent()
+    )
+
+    var slots by remember { mutableStateOf(template.slots) }
+    var currentSlot by remember {
+        mutableStateOf<Int?>(null)
+    }
+    TextTemplateTheme {
+        Column {
+            SlotsPreview(slots, currentSlot) {
+                currentSlot = it
+            }
+
+            currentSlot?.let { slotIndex ->
+                val slot = (slots[slotIndex] as Either.Right).value
+                SlotEditField(slot = slot) {
+                    val newSlots = slots.toMutableList()
+                    newSlots[slotIndex] = Either.Right(it)
+                    slots = newSlots.toList()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/joelt/texttemplate/ui/components/SlotsPreview.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/components/SlotsPreview.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import io.joelt.texttemplate.models.Either
 import io.joelt.texttemplate.models.Template
+import io.joelt.texttemplate.models.nextSlot
+import io.joelt.texttemplate.models.prevSlot
 import io.joelt.texttemplate.models.slots.Slot
 import io.joelt.texttemplate.ui.theme.TextTemplateTheme
 
@@ -85,7 +87,18 @@ private fun SlotsPreviewExample() {
 
             currentSlot?.let { slotIndex ->
                 val slot = (slots[slotIndex] as Either.Right).value
-                SlotEditField(slot = slot) {
+                val prevSlotIndex = slots.prevSlot(slotIndex)
+                val nextSlotIndex = slots.nextSlot(slotIndex)
+                var onLeft: (() -> Unit)? = { currentSlot = prevSlotIndex }
+                var onRight: (() -> Unit)? = { currentSlot = nextSlotIndex }
+                if (prevSlotIndex == -1) {
+                    onLeft = null
+                }
+                if (nextSlotIndex == -1) {
+                    onRight = null
+                }
+
+                SlotEditField(slot = slot, onLeft, onRight) {
                     val newSlots = slots.toMutableList()
                     newSlots[slotIndex] = Either.Right(it)
                     slots = newSlots.toList()


### PR DESCRIPTION
Editing controls are as such:
- Text is displayed, with editable slots highlighted in gray or yellow
- On clicking on an editable slot, the respective field will show up above the user's keyboard
- Typing into the field will display the changes in the field and in the text

Implementation:
- `AnnotatedString`s, with spans across the highlighted portions
- Using onClick of `Text` returns a character offset, which can be used to find the slot that was clicked
- Delegate the creation of the field to `SlotEditField` (may be expanded to date fields, dropdowns, etc.)

<p align="center">

  <img src="https://user-images.githubusercontent.com/5127468/196682594-7eed3009-4d14-4479-86d4-33bcd91f0b63.png" alt="Concept Art">
</p>