### PR TITLE
Use a DSL to manage screen specifications instead of classes

### DIFF
--- a/app/src/main/java/io/joelt/texttemplate/MainActivity.kt
+++ b/app/src/main/java/io/joelt/texttemplate/MainActivity.kt
@@ -1,15 +1,11 @@
 package io.joelt.texttemplate
 
-import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.*
 import androidx.core.view.WindowCompat
-import androidx.datastore.preferences.preferencesDataStore
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -17,7 +13,6 @@ import io.joelt.texttemplate.database.LocalPreferences
 import io.joelt.texttemplate.database.UserPreferences
 import io.joelt.texttemplate.database.UserPreferencesRepository
 import io.joelt.texttemplate.navigation.ScaffoldOptions
-import io.joelt.texttemplate.navigation.currentRouteAsState
 import io.joelt.texttemplate.ui.components.SystemBarScaffold
 import io.joelt.texttemplate.ui.screens.archived.ArchivedScreen
 import io.joelt.texttemplate.ui.screens.archived_preview.ArchivedPreviewScreen
@@ -28,13 +23,10 @@ import io.joelt.texttemplate.ui.screens.template_edit.TemplateEditScreen
 import io.joelt.texttemplate.ui.screens.template_preview.TemplatePreviewScreen
 import io.joelt.texttemplate.ui.screens.templates.TemplatesScreen
 import io.joelt.texttemplate.ui.theme.TextTemplateTheme
-
-private val Context.dataStore by preferencesDataStore(
-    name = "user_preferences"
-)
+import org.koin.android.ext.android.inject
 
 @Composable
-fun AppScaffold(scaffoldOptions: ScaffoldOptions, content: @Composable () -> Unit) {
+fun AppScaffold(scaffoldOptions: ScaffoldOptions, content: @Composable BoxScope.() -> Unit) {
     SystemBarScaffold(scaffoldOptions, content)
 }
 
@@ -43,37 +35,37 @@ class MainActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
 
-        val preferencesRepo = UserPreferencesRepository(dataStore)
         setContent {
             // Screens
             val screenStartIndex = 0
             val screens = listOf(
-                TemplatesScreen(),
-                TemplatePreviewScreen(),
-                TemplateEditScreen(),
-                DraftsScreen(),
-                ArchivedScreen(),
-                SettingsScreen(preferencesRepo),
-                DraftEditScreen(),
-                ArchivedPreviewScreen(),
+                TemplatesScreen,
+                TemplatePreviewScreen,
+                TemplateEditScreen,
+                DraftsScreen,
+                ArchivedScreen,
+                SettingsScreen,
+                TemplatesScreen,
+                DraftEditScreen,
+                ArchivedPreviewScreen,
             )
 
             // Navigation
             val navController = rememberNavController()
-            val currentRoute = navController.currentRouteAsState()
-            val screenMap = buildMap { screens.forEach { screen -> put(screen.route, screen) } }
-            val startingScreen = screens[screenStartIndex]
-            val currentScreen = screenMap[currentRoute] ?: startingScreen
+            var scaffoldOptions by remember { mutableStateOf(ScaffoldOptions()) }
 
             // Preferences
+            val preferencesRepo: UserPreferencesRepository by inject()
             val preferences by preferencesRepo.flow.collectAsState(initial = UserPreferences())
             CompositionLocalProvider(LocalPreferences provides preferences) {
                 TextTemplateTheme {
-                    AppScaffold(scaffoldOptions = currentScreen.scaffold(navController)) {
-                        NavHost(navController, startDestination = startingScreen.route) {
+                    AppScaffold(scaffoldOptions = scaffoldOptions) {
+                        NavHost(navController, startDestination = screens[screenStartIndex].route) {
                             screens.forEach { screen ->
-                                composable(screen.route, arguments = screen.arguments) {
-                                    screen.Composable(it, navController)
+                                composable(screen.route, arguments = screen.arguments) { backStackEntry ->
+                                    val screenContent = screen.contentFactory(backStackEntry, navController)
+                                    scaffoldOptions = screenContent.scaffoldOptions
+                                    screenContent.content()
                                 }
                             }
                         }

--- a/app/src/main/java/io/joelt/texttemplate/appModule.kt
+++ b/app/src/main/java/io/joelt/texttemplate/appModule.kt
@@ -2,6 +2,8 @@ package io.joelt.texttemplate
 
 import androidx.room.Room
 import io.joelt.texttemplate.database.TemplatesRepository
+import io.joelt.texttemplate.database.UserPreferencesRepository
+import io.joelt.texttemplate.database.dataStore
 import io.joelt.texttemplate.database.room.AppDatabase
 import io.joelt.texttemplate.database.room.RoomRepository
 import io.joelt.texttemplate.ui.screens.archived.ArchivedViewModel
@@ -24,6 +26,7 @@ val appModule = module {
         ).build()
     }
     single<TemplatesRepository> { RoomRepository(get()) }
+    single { UserPreferencesRepository(androidApplication().dataStore) }
     viewModel { TemplatesViewModel(get()) }
     viewModel { TemplateEditViewModel(get()) }
     viewModel { TemplatePreviewViewModel(get()) }

--- a/app/src/main/java/io/joelt/texttemplate/database/UserPreferencesRepository.kt
+++ b/app/src/main/java/io/joelt/texttemplate/database/UserPreferencesRepository.kt
@@ -1,11 +1,13 @@
 package io.joelt.texttemplate.database
 
+import android.content.Context
 import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -69,3 +71,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
 }
 
 val LocalPreferences = compositionLocalOf { UserPreferences() }
+
+val Context.dataStore by preferencesDataStore(
+    name = "user_preferences"
+)

--- a/app/src/main/java/io/joelt/texttemplate/navigation/ScaffoldOptions.kt
+++ b/app/src/main/java/io/joelt/texttemplate/navigation/ScaffoldOptions.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 
 data class ScaffoldOptions @OptIn(ExperimentalMaterial3Api::class) constructor(
-    val modifier: Modifier = Modifier,
-    val topBar: @Composable () -> Unit = {},
-    val bottomBar: @Composable () -> Unit = {},
-    val snackbarHost: @Composable () -> Unit = {},
-    val floatingActionButton: @Composable () -> Unit = {},
-    val floatingActionButtonPosition: FabPosition = FabPosition.End,
+    var modifier: Modifier = Modifier,
+    var topBar: @Composable () -> Unit = {},
+    var bottomBar: @Composable () -> Unit = {},
+    var snackbarHost: @Composable () -> Unit = {},
+    var floatingActionButton: @Composable () -> Unit = {},
+    var floatingActionButtonPosition: FabPosition = FabPosition.End,
 )

--- a/app/src/main/java/io/joelt/texttemplate/navigation/Screen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/navigation/Screen.kt
@@ -5,12 +5,61 @@ import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 
-interface Screen {
-    val route: String
-    val arguments: List<NamedNavArgument>
-    @Composable
-    fun scaffold(nav: NavHostController): ScaffoldOptions
 
-    @Composable
-    fun Composable(backStackEntry: NavBackStackEntry, nav: NavHostController)
+data class ScreenContent(
+    val scaffoldOptions: ScaffoldOptions = ScaffoldOptions(),
+    val content: @Composable () -> Unit = {}
+)
+
+class ScreenContentBuilder {
+    var scaffoldOptions = ScaffoldOptions()
+    var composable: @Composable () -> Unit = {}
+
+    fun scaffoldOptions(block: ScaffoldOptions.() -> Unit) {
+        block(scaffoldOptions)
+    }
+
+    fun content(block: @Composable () -> Unit) {
+        composable = block
+    }
+}
+
+typealias ContentFactory = @Composable (NavBackStackEntry, NavHostController) -> ScreenContent
+
+data class Screen(
+    val route: String,
+    val arguments: List<NamedNavArgument>,
+    val contentFactory: ContentFactory,
+)
+
+class ScreenBuilder {
+    lateinit var route: String
+    var arguments: List<NamedNavArgument> = emptyList()
+    var contentFactory: ContentFactory = { _, _ -> ScreenContent() }
+
+    fun contentFactory(block: @Composable ScreenContentBuilder.(NavBackStackEntry, NavHostController) -> ScreenContent) {
+        contentFactory = @Composable { backStack, nav ->
+            val builder = ScreenContentBuilder()
+            block(builder, backStack, nav)
+        }
+    }
+}
+
+fun buildScreen(block: ScreenBuilder.() -> Unit): Screen {
+    val builder = ScreenBuilder()
+    block(builder)
+
+    return Screen(
+        builder.route,
+        builder.arguments,
+        builder.contentFactory
+    )
+}
+
+@Composable
+fun buildScreenContent(block: @Composable ScreenContentBuilder.() -> Unit): ScreenContent {
+    val builder = ScreenContentBuilder()
+    block(builder)
+
+    return ScreenContent(builder.scaffoldOptions, builder.composable)
 }

--- a/app/src/main/java/io/joelt/texttemplate/ui/components/SystemBarScaffold.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/components/SystemBarScaffold.kt
@@ -28,7 +28,7 @@ fun SystemBarScaffold(
     floatingActionButtonPosition: FabPosition = FabPosition.End,
     containerColor: Color = MaterialTheme.colorScheme.background,
     contentColor: Color = contentColorFor(containerColor),
-    content: @Composable () -> Unit
+    content: @Composable BoxScope.() -> Unit
 ) {
     Box(modifier = Modifier
         .background(MaterialTheme.colorScheme.background)
@@ -57,7 +57,7 @@ fun SystemBarScaffold(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SystemBarScaffold(scaffoldOptions: ScaffoldOptions, content: @Composable () -> Unit) {
+fun SystemBarScaffold(scaffoldOptions: ScaffoldOptions, content: @Composable BoxScope.() -> Unit) {
     SystemBarScaffold(
         modifier = scaffoldOptions.modifier,
         topBar = scaffoldOptions.topBar,

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/archived/ArchivedScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/archived/ArchivedScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import io.joelt.texttemplate.models.Draft
 import io.joelt.texttemplate.navigation.*
@@ -21,40 +19,38 @@ val Route.archived: String
     get() = "archived"
 
 @OptIn(ExperimentalMaterial3Api::class)
-class ArchivedScreen : Screen {
-    override val route: String = Route.archived
-    override val arguments: List<NamedNavArgument> = emptyList()
-    @Composable
-    override fun scaffold(nav: NavHostController): ScaffoldOptions {
-        val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-        return ScaffoldOptions(
-            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-            topBar = { TopNavBar(nav, scrollBehavior) },
-            bottomBar = { BottomNavBar(nav) }
-        )
-    }
-
-    @Composable
-    override fun Composable(backStackEntry: NavBackStackEntry, nav: NavHostController) {
-        ArchivedScreen(nav)
-    }
-}
-
 @Composable
-private fun ArchivedScreenContent(archived: List<Draft>?, onArchivedClick: (Draft) -> Unit) {
-    DraftList(drafts = archived, onItemClick = onArchivedClick)
-}
-
-@Composable
-private fun ArchivedScreen(
+private fun archivedScreenContent(
     nav: NavHostController,
-    viewModel: ArchivedViewModel = koinViewModel()
-) {
-    LaunchedEffect(Unit) {
-        viewModel.loadArchived()
+    archived: List<Draft>?,
+    onArchivedClick: (Draft) -> Unit
+) = buildScreenContent {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    scaffoldOptions {
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+        topBar = { TopNavBar(nav, scrollBehavior) }
+        bottomBar = { BottomNavBar(nav) }
     }
 
-    ArchivedScreenContent(archived = viewModel.archived) {
-        nav.navigate(Route.archivedPreview(it.id))
+    content {
+        DraftList(drafts = archived, onItemClick = onArchivedClick)
+    }
+}
+
+val ArchivedScreen = buildScreen {
+    route = Route.archived
+    arguments = emptyList()
+
+    contentFactory { _, nav ->
+        val viewModel: ArchivedViewModel = koinViewModel()
+
+        LaunchedEffect(Unit) {
+            viewModel.loadArchived()
+        }
+
+        archivedScreenContent(
+            nav = nav,
+            archived = viewModel.archived,
+            onArchivedClick = { nav.navigate(Route.archivedPreview(it.id)) })
     }
 }

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/archived_preview/ArchivedPreviewScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/archived_preview/ArchivedPreviewScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.*
-import androidx.navigation.compose.rememberNavController
 import io.joelt.texttemplate.AppScaffold
 import io.joelt.texttemplate.R
 import io.joelt.texttemplate.models.Draft
@@ -26,8 +25,8 @@ fun Route.archivedPreview(archivedId: Long) = "archived/$archivedId"
 
 @Composable
 private fun archivedPreviewScreenContent(
-    nav: NavHostController,
     archived: Draft?,
+    onBack: () -> Unit,
     onDelete: () -> Unit,
     onEdit: () -> Unit
 ) = buildScreenContent {
@@ -35,7 +34,7 @@ private fun archivedPreviewScreenContent(
     scaffoldOptions {
         topBar = {
             ArchivedPreviewTopNavBar(
-                nav,
+                onBack = onBack,
                 onDeleteArchived = { showConfirmDeleteDialog = true })
         }
         floatingActionButton = {
@@ -93,8 +92,8 @@ val ArchivedPreviewScreen = buildScreen {
         }
 
         archivedPreviewScreenContent(
-            nav = nav,
             archived = viewModel.archived,
+            onBack = { nav.popBackStack() },
             onDelete = { viewModel.deleteArchived(nav) },
             onEdit = { viewModel.unarchive(nav) })
     }
@@ -106,8 +105,7 @@ private fun ArchivedPreviewScreenPreview() {
     val template = genTemplates(1)[0]
     val archived = Draft(template)
 
-    val nav = rememberNavController()
-    val screen = archivedPreviewScreenContent(nav, archived, {}, {})
+    val screen = archivedPreviewScreenContent(archived, {}, {}, {})
     TextTemplateTheme {
         AppScaffold(scaffoldOptions = screen.scaffoldOptions) {
             screen.content()

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/archived_preview/ArchivedPreviewScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/archived_preview/ArchivedPreviewScreen.kt
@@ -24,26 +24,20 @@ import org.koin.androidx.compose.koinViewModel
 
 fun Route.archivedPreview(archivedId: Long) = "archived/$archivedId"
 
-class ArchivedPreviewController {
-    var onEditArchived = {}
-    var onDeleteArchived = {}
-}
-
-class ArchivedPreviewScreen : Screen {
-    private val controller = ArchivedPreviewController()
-
-    override val route: String = "archived/{archivedId}"
-    override val arguments: List<NamedNavArgument> = listOf(
-        navArgument("archivedId") { type = NavType.LongType }
-    )
-
-    @Composable
-    override fun scaffold(nav: NavHostController) = ScaffoldOptions(
+@Composable
+private fun archivedPreviewScreenContent(
+    nav: NavHostController,
+    archived: Draft?,
+    onDelete: () -> Unit,
+    onEdit: () -> Unit
+) = buildScreenContent {
+    var showConfirmDeleteDialog by remember { mutableStateOf(false) }
+    scaffoldOptions {
         topBar = {
             ArchivedPreviewTopNavBar(
                 nav,
-                onDeleteArchived = { controller.onDeleteArchived() })
-        },
+                onDeleteArchived = { showConfirmDeleteDialog = true })
+        }
         floatingActionButton = {
             ExtendedFloatingActionButton(icon = {
                 Icon(
@@ -52,67 +46,58 @@ class ArchivedPreviewScreen : Screen {
                 )
             }, text = {
                 Text(text = stringResource(R.string.fill_up_archived))
-            }, onClick = { controller.onEditArchived() })
+            }, onClick = onEdit)
         }
+    }
+
+    content {
+        if (showConfirmDeleteDialog) {
+            AlertDialog(
+                title = { Text(text = stringResource(R.string.archived_confirm_delete_title)) },
+                text = { Text(text = stringResource(R.string.archived_confirm_delete)) },
+                onDismissRequest = { showConfirmDeleteDialog = false },
+                confirmButton = {
+                    TextButton(onClick = onDelete) {
+                        Text(text = stringResource(R.string.dialog_delete))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showConfirmDeleteDialog = false }) {
+                        Text(text = stringResource(R.string.dialog_cancel))
+                    }
+                }
+            )
+        }
+
+        if (archived == null) {
+            Spacer(Modifier.height(32.dp))
+            CircularProgressIndicator()
+        } else {
+            TemplatePreview(name = archived.name, slots = archived.slots)
+        }
+    }
+}
+
+val ArchivedPreviewScreen = buildScreen {
+    route = "archived/{archivedId}"
+    arguments = listOf(
+        navArgument("archivedId") { type = NavType.LongType }
     )
 
-    @Composable
-    override fun Composable(backStackEntry: NavBackStackEntry, nav: NavHostController) {
+    contentFactory { backStackEntry, nav ->
         val archivedId = backStackEntry.arguments!!.getLong("archivedId")
-        ArchivedPreviewScreen(nav, controller, archivedId)
-    }
-}
+        val viewModel: ArchivedPreviewViewModel = koinViewModel()
 
-@Composable
-private fun ArchivedPreviewScreenContent(
-    archived: Draft?,
-) {
-    if (archived == null) {
-        Spacer(Modifier.height(32.dp))
-        CircularProgressIndicator()
-        return
-    }
-
-    TemplatePreview(name = archived.name, slots = archived.slots)
-}
-
-@Composable
-private fun ArchivedPreviewScreen(
-    nav: NavHostController,
-    screenController: ArchivedPreviewController,
-    archivedId: Long,
-    viewModel: ArchivedPreviewViewModel = koinViewModel()
-) {
-    var showConfirmDeleteDialog by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        viewModel.loadArchived(archivedId)
-        screenController.onEditArchived = {
-            viewModel.unarchive(nav)
+        LaunchedEffect(Unit) {
+            viewModel.loadArchived(archivedId)
         }
-        screenController.onDeleteArchived = {
-            showConfirmDeleteDialog = true
-        }
-    }
 
-    if (showConfirmDeleteDialog) {
-        AlertDialog(
-            title = { Text(text = stringResource(R.string.archived_confirm_delete_title)) },
-            text = { Text(text = stringResource(R.string.archived_confirm_delete)) },
-            onDismissRequest = { showConfirmDeleteDialog = false },
-            confirmButton = {
-                TextButton(onClick = { viewModel.deleteArchived(nav) }) {
-                    Text(text = stringResource(R.string.dialog_delete))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showConfirmDeleteDialog = false }) {
-                    Text(text = stringResource(R.string.dialog_cancel))
-                }
-            }
-        )
+        archivedPreviewScreenContent(
+            nav = nav,
+            archived = viewModel.archived,
+            onDelete = { viewModel.deleteArchived(nav) },
+            onEdit = { viewModel.unarchive(nav) })
     }
-
-    ArchivedPreviewScreenContent(viewModel.archived)
 }
 
 @Preview(showBackground = true)
@@ -121,11 +106,11 @@ private fun ArchivedPreviewScreenPreview() {
     val template = genTemplates(1)[0]
     val archived = Draft(template)
 
-    val screen = ArchivedPreviewScreen()
     val nav = rememberNavController()
+    val screen = archivedPreviewScreenContent(nav, archived, {}, {})
     TextTemplateTheme {
-        AppScaffold(scaffoldOptions = screen.scaffold(nav)) {
-            ArchivedPreviewScreenContent(archived)
+        AppScaffold(scaffoldOptions = screen.scaffoldOptions) {
+            screen.content()
         }
     }
 }

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/archived_preview/ArchivedPreviewTopNavBar.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/archived_preview/ArchivedPreviewTopNavBar.kt
@@ -9,16 +9,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavHostController
 import io.joelt.texttemplate.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ArchivedPreviewTopNavBar(nav: NavHostController, onDeleteArchived: () -> Unit) {
+fun ArchivedPreviewTopNavBar(onBack: () -> Unit, onDeleteArchived: () -> Unit) {
     val backIconBtn = @Composable {
-        IconButton(onClick = {
-            nav.popBackStack()
-        }) {
+        IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.Default.ArrowBack,
                 contentDescription = stringResource(id = R.string.navbar_back),

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditScreen.kt
@@ -36,6 +36,7 @@ private fun draftEditScreenContent(
     val clipboardManager = LocalClipboardManager.current
     val scope = rememberCoroutineScope()
     val clipboardMessage = stringResource(R.string.text_copied_to_clipboard)
+    var showConfirmDeleteDialog by remember { mutableStateOf(false) }
 
     scaffoldOptions {
         snackbarHost = { SnackbarHost(snackbarHostState) }
@@ -43,7 +44,7 @@ private fun draftEditScreenContent(
             DraftEditTopNavBar(
                 nav,
                 onSave = onSave,
-                onDelete = onDelete,
+                onDelete = { showConfirmDeleteDialog = true },
                 onCopyToClipboard = {
                     val content = onCopyToClipboard()
                     content?.let {
@@ -57,7 +58,6 @@ private fun draftEditScreenContent(
     }
 
     content {
-        var showConfirmDeleteDialog by remember { mutableStateOf(false) }
         if (showConfirmDeleteDialog) {
             AlertDialog(
                 title = { Text(text = stringResource(R.string.draft_confirm_delete_title)) },

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditScreen.kt
@@ -23,125 +23,106 @@ fun Route.draftEdit(draftId: Long) = "drafts/$draftId/edit/0"
 
 fun Route.createDraft(fromTemplateId: Long) = "drafts/0/edit/$fromTemplateId"
 
-private class DraftEditController {
-    var snackbarHostState: SnackbarHostState? = null
-    var onSave = {}
-    var onDelete = {}
-    var onCopyToClipboard = {}
+@Composable
+private fun draftEditScreenContent(
+    nav: NavHostController,
+    draft: Draft?,
+    onDraftChange: (Draft) -> Unit,
+    onSave: () -> Unit,
+    onDelete: () -> Unit,
+    onCopyToClipboard: () -> String?,
+) = buildScreenContent {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val clipboardManager = LocalClipboardManager.current
+    val scope = rememberCoroutineScope()
+    val clipboardMessage = stringResource(R.string.text_copied_to_clipboard)
+
+    scaffoldOptions {
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+        topBar = {
+            DraftEditTopNavBar(
+                nav,
+                onSave = onSave,
+                onDelete = onDelete,
+                onCopyToClipboard = {
+                    val content = onCopyToClipboard()
+                    content?.let {
+                        clipboardManager.setText(AnnotatedString(content))
+                        scope.launch {
+                            snackbarHostState.showSnackbar(clipboardMessage)
+                        }
+                    }
+                })
+        }
+    }
+
+    content {
+        var showConfirmDeleteDialog by remember { mutableStateOf(false) }
+        if (showConfirmDeleteDialog) {
+            AlertDialog(
+                title = { Text(text = stringResource(R.string.draft_confirm_delete_title)) },
+                text = { Text(text = stringResource(R.string.draft_confirm_delete)) },
+                onDismissRequest = { showConfirmDeleteDialog = false },
+                confirmButton = {
+                    TextButton(onClick = onDelete) {
+                        Text(text = stringResource(R.string.dialog_delete))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showConfirmDeleteDialog = false }) {
+                        Text(text = stringResource(R.string.dialog_cancel))
+                    }
+                }
+            )
+        }
+
+        if (draft == null) {
+            Spacer(Modifier.height(32.dp))
+            CircularProgressIndicator()
+        } else {
+            DraftEditor(state = DraftEditorState(draft), onStateChange = {
+                onDraftChange(draft.copy(name = it.name, slots = it.slots))
+            })
+        }
+    }
 }
 
-class DraftEditScreen : Screen {
-    private val controller = DraftEditController()
-
-    override val route: String = "drafts/{draftId}/edit/{templateId}"
-    override val arguments: List<NamedNavArgument> = listOf(
+val DraftEditScreen = buildScreen {
+    route = "drafts/{draftId}/edit/{templateId}"
+    arguments = listOf(
         navArgument("draftId") { type = NavType.LongType },
         navArgument("templateId") { type = NavType.LongType }
     )
 
-    @Composable
-    override fun scaffold(nav: NavHostController): ScaffoldOptions {
-        val snackbarHostState = remember { SnackbarHostState() }
-        controller.snackbarHostState = snackbarHostState
-
-        return ScaffoldOptions(
-            snackbarHost = { SnackbarHost(snackbarHostState) },
-            topBar = {
-                DraftEditTopNavBar(
-                    nav,
-                    onSave = { controller.onSave() },
-                    onDelete = { controller.onDelete() },
-                    onCopyToClipboard = { controller.onCopyToClipboard() })
-            },
-        )
-    }
-
-    @Composable
-    override fun Composable(backStackEntry: NavBackStackEntry, nav: NavHostController) {
+    contentFactory { backStackEntry, nav ->
         val draftId = backStackEntry.arguments!!.getLong("draftId")
         val templateId = backStackEntry.arguments!!.getLong("templateId")
-        DraftEditScreen(nav, controller, draftId, templateId)
-    }
-}
+        val viewModel: DraftEditViewModel = koinViewModel()
 
-@Composable
-private fun DraftEditScreenContent(draft: Draft?, onDraftChange: (Draft) -> Unit) {
-    if (draft == null) {
-        Spacer(Modifier.height(32.dp))
-        CircularProgressIndicator()
-        return
-    }
-
-    DraftEditor(state = DraftEditorState(draft), onStateChange = {
-        onDraftChange(draft.copy(name = it.name, slots = it.slots))
-    })
-}
-
-@Composable
-private fun DraftEditScreen(
-    nav: NavHostController,
-    screenController: DraftEditController,
-    draftId: Long,
-    templateId: Long,
-    viewModel: DraftEditViewModel = koinViewModel()
-) {
-    val clipboardManager = LocalClipboardManager.current
-    val clipboardMessage = stringResource(R.string.text_copied_to_clipboard)
-    val scope = rememberCoroutineScope()
-
-    var showConfirmDeleteDialog by remember { mutableStateOf(false) }
-
-    LaunchedEffect(Unit) {
-        if (draftId != 0L) {
-            viewModel.loadDraft(draftId)
-        } else if (templateId != 0L) {
-            viewModel.createDraft(templateId)
-        }
-
-        screenController.onSave = {
-            viewModel.saveDraft(nav)
-        }
-
-        screenController.onDelete = {
-            showConfirmDeleteDialog = true
-        }
-
-        screenController.onCopyToClipboard = {
-            viewModel.draft?.let { draft ->
-                val text = draft.slots.joinToString {
-                    when (it) {
-                        is Either.Left -> it.value
-                        is Either.Right -> it.value.toDisplayString()
-                    }
-                }
-
-                clipboardManager.setText(AnnotatedString(text))
-                scope.launch {
-                    screenController.snackbarHostState?.showSnackbar(clipboardMessage)
-                }
+        LaunchedEffect(Unit) {
+            if (draftId != 0L) {
+                viewModel.loadDraft(draftId)
+            } else if (templateId != 0L) {
+                viewModel.createDraft(templateId)
             }
         }
-    }
 
-    if (showConfirmDeleteDialog) {
-        AlertDialog(
-            title = { Text(text = stringResource(R.string.draft_confirm_delete_title)) },
-            text = { Text(text = stringResource(R.string.draft_confirm_delete)) },
-            onDismissRequest = { showConfirmDeleteDialog = false },
-            confirmButton = {
-                TextButton(onClick = { viewModel.deleteDraft(nav) }) {
-                    Text(text = stringResource(R.string.dialog_delete))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showConfirmDeleteDialog = false }) {
-                    Text(text = stringResource(R.string.dialog_cancel))
+        draftEditScreenContent(
+            nav = nav,
+            draft = viewModel.draft,
+            onDraftChange = { viewModel.draft = it },
+            onSave = { viewModel.saveDraft(nav) },
+            onDelete = { viewModel.deleteDraft(nav) },
+            onCopyToClipboard = {
+                viewModel.draft?.let { draft ->
+                    draft.slots.joinToString {
+                        when (it) {
+                            is Either.Left -> it.value
+                            is Either.Right -> it.value.toDisplayString()
+                        }
+                    }
                 }
             }
         )
-    }
-
-    DraftEditScreenContent(viewModel.draft) {
-        viewModel.draft = it
     }
 }

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditScreen.kt
@@ -1,5 +1,6 @@
 package io.joelt.texttemplate.ui.screens.draft_edit
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.*
@@ -16,6 +17,7 @@ import io.joelt.texttemplate.models.Either
 import io.joelt.texttemplate.navigation.*
 import io.joelt.texttemplate.ui.components.DraftEditor
 import io.joelt.texttemplate.ui.components.DraftEditorState
+import io.joelt.texttemplate.ui.screens.drafts.drafts
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
@@ -23,10 +25,18 @@ fun Route.draftEdit(draftId: Long) = "drafts/$draftId/edit/0"
 
 fun Route.createDraft(fromTemplateId: Long) = "drafts/0/edit/$fromTemplateId"
 
+fun NavHostController.navigateBackToDrafts() {
+    navigate(Route.drafts) {
+        this@navigateBackToDrafts.graph.startDestinationRoute?.let { route ->
+            popUpTo(route)
+        }
+    }
+}
+
 @Composable
 private fun draftEditScreenContent(
-    nav: NavHostController,
     draft: Draft?,
+    onBack: () -> Unit,
     onDraftChange: (Draft) -> Unit,
     onSave: () -> Unit,
     onDelete: () -> Unit,
@@ -42,7 +52,7 @@ private fun draftEditScreenContent(
         snackbarHost = { SnackbarHost(snackbarHostState) }
         topBar = {
             DraftEditTopNavBar(
-                nav,
+                onBack = onBack,
                 onSave = onSave,
                 onDelete = { showConfirmDeleteDialog = true },
                 onCopyToClipboard = {
@@ -107,9 +117,13 @@ val DraftEditScreen = buildScreen {
             }
         }
 
+        BackHandler(enabled = true) {
+            nav.navigateBackToDrafts()
+        }
+
         draftEditScreenContent(
-            nav = nav,
             draft = viewModel.draft,
+            onBack = { nav.navigateBackToDrafts() },
             onDraftChange = { viewModel.draft = it },
             onSave = { viewModel.saveDraft(nav) },
             onDelete = { viewModel.deleteDraft(nav) },

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditTopNavBar.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/draft_edit/DraftEditTopNavBar.kt
@@ -1,6 +1,5 @@
 package io.joelt.texttemplate.ui.screens.draft_edit
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -12,30 +11,13 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavHostController
 import io.joelt.texttemplate.R
-import io.joelt.texttemplate.navigation.Route
-import io.joelt.texttemplate.ui.screens.drafts.drafts
-
-fun NavHostController.navigateBackToDrafts() {
-    navigate(Route.drafts) {
-        this@navigateBackToDrafts.graph.startDestinationRoute?.let { route ->
-            popUpTo(route)
-        }
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DraftEditTopNavBar(nav: NavHostController, onSave: () -> Unit, onDelete: () -> Unit, onCopyToClipboard: () -> Unit) {
-    BackHandler(enabled = true) {
-        nav.navigateBackToDrafts()
-    }
-
+fun DraftEditTopNavBar(onBack: () -> Unit, onSave: () -> Unit, onDelete: () -> Unit, onCopyToClipboard: () -> Unit) {
     val backIconBtn = @Composable {
-        IconButton(onClick = {
-            nav.navigateBackToDrafts()
-        }) {
+        IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.Default.Close,
                 contentDescription = stringResource(id = R.string.navbar_back),

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/drafts/DraftsScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/drafts/DraftsScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import io.joelt.texttemplate.models.Draft
 import io.joelt.texttemplate.navigation.*
@@ -21,44 +19,37 @@ val Route.drafts: String
     get() = "drafts"
 
 @OptIn(ExperimentalMaterial3Api::class)
-class DraftsScreen : Screen {
-    override val route: String = Route.drafts
-    override val arguments: List<NamedNavArgument> = emptyList()
-
-    @Composable
-    override fun scaffold(nav: NavHostController): ScaffoldOptions {
-        val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-        return ScaffoldOptions(
-            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-            topBar = { TopNavBar(nav, scrollBehavior) },
-            bottomBar = { BottomNavBar(nav) }
-        )
-    }
-
-    @Composable
-    override fun Composable(backStackEntry: NavBackStackEntry, nav: NavHostController) {
-        DraftsScreen(nav)
-    }
-}
-
 @Composable
-private fun DraftsScreenContent(
+private fun draftsScreenContent(
+    nav: NavHostController,
     drafts: List<Draft>?,
     onDraftClick: (Draft) -> Unit
-) {
-    DraftList(drafts, onItemClick = onDraftClick)
-}
-
-@Composable
-private fun DraftsScreen(
-    nav: NavHostController,
-    viewModel: DraftsViewModel = koinViewModel()
-) {
-    LaunchedEffect(Unit) {
-        viewModel.loadDrafts()
+) = buildScreenContent {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    scaffoldOptions {
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+        topBar = { TopNavBar(nav, scrollBehavior) }
+        bottomBar = { BottomNavBar(nav) }
     }
 
-    DraftsScreenContent(viewModel.drafts) {
-        nav.navigate(Route.draftEdit(it.id))
+    content {
+        DraftList(drafts, onItemClick = onDraftClick)
+    }
+}
+
+val DraftsScreen = buildScreen {
+    route = Route.drafts
+    arguments = emptyList()
+
+    contentFactory { _, nav ->
+        val viewModel: DraftsViewModel = koinViewModel()
+        LaunchedEffect(Unit) {
+            viewModel.loadDrafts()
+        }
+
+        draftsScreenContent(
+            nav = nav,
+            drafts = viewModel.drafts,
+            onDraftClick = { nav.navigate(Route.draftEdit(it.id)) })
     }
 }

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/settings/SettingsScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
 import io.joelt.texttemplate.R
 import io.joelt.texttemplate.database.HourFormat
 import io.joelt.texttemplate.database.LocalPreferences
@@ -36,12 +35,12 @@ private fun SettingTitle(text: String) {
 
 @Composable
 private fun settingsScreenContent(
-    nav: NavHostController,
+    onBack: () -> Unit,
     onUpdateThemeColor: (ThemeColor) -> Unit,
     onUpdateHourFormat: (HourFormat) -> Unit,
 ) = buildScreenContent {
     scaffoldOptions {
-        topBar = { SettingsTopNavBar(nav) }
+        topBar = { SettingsTopNavBar(onBack = onBack) }
     }
 
     content {
@@ -83,7 +82,7 @@ val SettingsScreen = buildScreen {
         val scope = rememberCoroutineScope()
         val preferencesRepo: UserPreferencesRepository = get()
         settingsScreenContent(
-            nav = nav,
+            onBack = { nav.popBackStack() },
             onUpdateThemeColor = { scope.launch { preferencesRepo.updateThemeColor(it) } },
             onUpdateHourFormat = { scope.launch { preferencesRepo.updateHourFormat(it) } })
     }

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/settings/SettingsTopNavBar.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/settings/SettingsTopNavBar.kt
@@ -9,17 +9,14 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavHostController
 import io.joelt.texttemplate.R
 import io.joelt.texttemplate.ui.theme.Typography
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsTopNavBar(nav: NavHostController) {
+fun SettingsTopNavBar(onBack: () -> Unit) {
     val backIconBtn = @Composable {
-        IconButton(onClick = {
-            nav.popBackStack()
-        }) {
+        IconButton(onBack) {
             Icon(
                 imageVector = Icons.Default.ArrowBack,
                 contentDescription = stringResource(id = R.string.navbar_back),

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/template_edit/TemplateEditScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/template_edit/TemplateEditScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.*
-import androidx.navigation.compose.rememberNavController
 import io.joelt.texttemplate.AppScaffold
 import io.joelt.texttemplate.R
 import io.joelt.texttemplate.models.Template

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/template_edit/TemplateEditScreen.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/template_edit/TemplateEditScreen.kt
@@ -27,36 +27,6 @@ fun Route.templateEdit(templateId: Long) = "templates/$templateId/edit"
 val Route.createTemplate: String
     get() = "templates/0/edit"
 
-class TemplateEditController {
-    var onSave = {}
-    var onBack = {}
-}
-
-class TemplateEditScreen : Screen {
-    private val controller = TemplateEditController()
-
-    override val route: String = "templates/{templateId}/edit"
-    override val arguments: List<NamedNavArgument> = listOf(
-        navArgument("templateId") { type = NavType.LongType }
-    )
-
-    @Composable
-    override fun scaffold(nav: NavHostController) = ScaffoldOptions(
-        topBar = {
-            TemplateEditTopNavBar(
-                nav,
-                onSave = { controller.onSave() },
-                onBack = { controller.onBack() })
-        }
-    )
-
-    @Composable
-    override fun Composable(backStackEntry: NavBackStackEntry, nav: NavHostController) {
-        val templateId = backStackEntry.arguments!!.getLong("templateId")
-        TemplateEditScreen(nav, controller, templateId)
-    }
-}
-
 data class TemplateEditState(
     val template: Template,
     val editorState: TemplateEditorState
@@ -76,69 +46,88 @@ data class TemplateEditState(
 }
 
 @Composable
-private fun TemplateEditScreenContent(
+private fun templateEditScreenContent(
     state: TemplateEditState?,
     onStateChange: (TemplateEditState) -> Unit,
-) {
-    if (state == null) {
-        Spacer(Modifier.height(32.dp))
-        CircularProgressIndicator()
-        return
+    templateChanged: Boolean,
+    onSave: () -> Unit,
+    onBack: () -> Unit,
+) = buildScreenContent {
+    var showConfirmDiscardDialog by remember { mutableStateOf(false) }
+    scaffoldOptions {
+        topBar = {
+            TemplateEditTopNavBar(
+                onSave = onSave,
+                onBack = {
+                    if (templateChanged) {
+                        showConfirmDiscardDialog = true
+                    } else {
+                        onBack()
+                    }
+                }
+            )
+        }
     }
 
-    TemplateEditor(
-        state = state.editorState,
-        onStateChange = { onStateChange(state.withEditorState(it)) })
+    content {
+        if (showConfirmDiscardDialog) {
+            AlertDialog(
+                title = { Text(text = stringResource(R.string.template_confirm_discard_title)) },
+                text = { Text(text = stringResource(R.string.template_confirm_discard)) },
+                onDismissRequest = { showConfirmDiscardDialog = false },
+                confirmButton = {
+                    TextButton(onClick = onBack) {
+                        Text(text = stringResource(R.string.dialog_discard))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showConfirmDiscardDialog = false }) {
+                        Text(text = stringResource(R.string.dialog_cancel))
+                    }
+                }
+            )
+        }
+
+        if (state == null) {
+            Spacer(Modifier.height(32.dp))
+            CircularProgressIndicator()
+        } else {
+            TemplateEditor(
+                state = state.editorState,
+                onStateChange = { onStateChange(state.withEditorState(it)) })
+        }
+    }
 }
 
-@Composable
-private fun TemplateEditScreen(
-    nav: NavHostController,
-    screenController: TemplateEditController,
-    templateId: Long,
-    viewModel: TemplateEditViewModel = koinViewModel()
-) {
-    val defaultName = stringResource(R.string.new_template_name)
-    var showConfirmDiscardDialog by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        // The LaunchedEffect gets run again when orientation changes
-        if (viewModel.screenState == null) {
-            viewModel.loadTemplate(templateId, defaultName)
-        }
+val TemplateEditScreen = buildScreen {
+    route = "templates/{templateId}/edit"
+    arguments = listOf(
+        navArgument("templateId") { type = NavType.LongType }
+    )
 
-        screenController.onSave = {
-            viewModel.saveTemplate(nav)
-        }
+    contentFactory { backStackEntry, nav ->
+        val defaultName = stringResource(R.string.new_template_name)
+        val templateId = backStackEntry.arguments!!.getLong("templateId")
+        val viewModel: TemplateEditViewModel = koinViewModel()
 
-        screenController.onBack = {
-            if (viewModel.templateChanged()) {
-                showConfirmDiscardDialog = true
-            } else {
-                nav.popBackStack()
+        LaunchedEffect(Unit) {
+            // The LaunchedEffect gets run again when orientation changes
+            // don't reload when the orientation changes
+            if (viewModel.screenState == null) {
+                viewModel.loadTemplate(templateId, defaultName)
             }
         }
-    }
 
-    if (showConfirmDiscardDialog) {
-        AlertDialog(
-            title = { Text(text = stringResource(R.string.template_confirm_discard_title)) },
-            text = { Text(text = stringResource(R.string.template_confirm_discard)) },
-            onDismissRequest = { showConfirmDiscardDialog = false },
-            confirmButton = {
-                TextButton(onClick = { nav.popBackStack() }) {
-                    Text(text = stringResource(R.string.dialog_discard))
-                }
+        templateEditScreenContent(
+            viewModel.screenState,
+            onStateChange = { viewModel.screenState = it },
+            viewModel.templateChanged(),
+            onSave = {
+                viewModel.saveTemplate(nav)
             },
-            dismissButton = {
-                TextButton(onClick = { showConfirmDiscardDialog = false }) {
-                    Text(text = stringResource(R.string.dialog_cancel))
-                }
-            }
-        )
-    }
-
-    TemplateEditScreenContent(viewModel.screenState) {
-        viewModel.screenState = it
+            onBack = {
+                nav.popBackStack()
+            })
     }
 }
 
@@ -148,11 +137,15 @@ private fun TemplateEditScreenPreview() {
     val template = genTemplates(1)[0]
     var screenState by remember { mutableStateOf(TemplateEditState(template)) }
 
-    val screen = TemplateEditScreen()
-    val nav = rememberNavController()
+    val screen = templateEditScreenContent(
+        state = screenState,
+        onStateChange = { screenState = it },
+        templateChanged = true,
+        onSave = {},
+        onBack = {})
     TextTemplateTheme {
-        AppScaffold(scaffoldOptions = screen.scaffold(nav)) {
-            TemplateEditScreenContent(screenState) { screenState = it }
+        AppScaffold(scaffoldOptions = screen.scaffoldOptions) {
+            screen.content()
         }
     }
 }

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/template_edit/TemplateEditTopNavBar.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/template_edit/TemplateEditTopNavBar.kt
@@ -14,7 +14,7 @@ import io.joelt.texttemplate.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TemplateEditTopNavBar(nav: NavHostController, onSave: () -> Unit, onBack: () -> Unit) {
+fun TemplateEditTopNavBar(onSave: () -> Unit, onBack: () -> Unit) {
     val backIconBtn = @Composable {
         IconButton(onClick = onBack) {
             Icon(

--- a/app/src/main/java/io/joelt/texttemplate/ui/screens/template_preview/TemplatePreviewTopNavBar.kt
+++ b/app/src/main/java/io/joelt/texttemplate/ui/screens/template_preview/TemplatePreviewTopNavBar.kt
@@ -19,7 +19,7 @@ import io.joelt.texttemplate.R
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TemplatePreviewTopNavBar(
-    nav: NavHostController,
+    onBack: () -> Unit,
     onDeleteTemplate: () -> Unit,
     onEditTemplate: () -> Unit
 ) {
@@ -29,9 +29,7 @@ fun TemplatePreviewTopNavBar(
     TopAppBar(
         title = {},
         navigationIcon = {
-            IconButton(onClick = {
-                nav.popBackStack()
-            }) {
+            IconButton(onClick = onBack) {
                 Icon(
                     imageVector = Icons.Default.ArrowBack,
                     contentDescription = stringResource(id = R.string.navbar_back),


### PR DESCRIPTION
Defining classes that implement the `Screen` interface has been a problem. Composable information that needs to be shared between the scaffold and the screen body are shared in quite a hacky way: by using a class that contains a bunch of lambdas. The class was referred to as the "controller".

Instead, the separation should be made between the routing constants and the composable components. This means that I should be able to access the routing information (route name, arguments) without constructing the composable. These two things are separate. On the flip side, when I do create the screen composable, the screen's scaffold should also be made.

This is all done through a DSL:
```kotlin
// This part makes the composable components: the scaffold and the screen body
@Composable
private fun myScreenContent() = buildScreenContent {
    scaffoldOptions {
        topBar = {
            TopNavBar()
        }
    }

    content {
        Text("hello world!")
    }
}

// This part creates the screen arguments, and also puts together the screen content composable
val MyScreen = buildScreen {
    route = "home"
    arguments = listOf(
        navArgument("id") { type = NavType.LongType }
    )
    contentFactory { backStackEntry, nav ->
        val templateId = backStackEntry.arguments!!.getLong("id")
        val viewModel: MyScreenViewModel = koinViewModel()
        myScreenContent()
    }
}
```

See the implementation in [Screen.kt](app/src/main/java/io/joelt/texttemplate/navigation/Screen.kt)

This looks nicer than the class version, but it still does not solve the issue of retaining Scaffolds between screens, that may have no solution other than to use a flag to check.